### PR TITLE
Adding MYSQLCLIENT_STATIC env check.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -19,7 +19,9 @@ fn main() {
         println!("cargo:rustc-link-search=native={}", path);
     }
 
-    if cfg!(all(windows, target_env="gnu")) {
+    if env::var_os("MYSQLCLIENT_STATIC").is_some() {
+        println!("cargo:rustc-link-lib=static=mysqlclient");
+    } else if cfg!(all(windows, target_env="gnu")) {
         println!("cargo:rustc-link-lib=dylib=mysql");
     } else if cfg!(all(windows, target_env="msvc")) {
         println!("cargo:rustc-link-lib=static=mysqlclient");


### PR DESCRIPTION
Most *-sys crate's allow to force a STATIC build.
This patch adds this function to mysqlcient-sys.

This together with a custom static build mysqlclient library you can
build a static application using diesel-rs for example.
You do have to configure MYSQLCLIENT_NO_PKG_CONFIG=true and MYSQLCLIENT_LIB_DIR=/path also to prevent
pkgconfig from running and still getting the needed information.